### PR TITLE
fix: override ejs to 3.1.10 to patch critical template injection (GHSA-phwq-j96m-2c2q)

### DIFF
--- a/projects/02_trivia_api/starter/frontend/package-lock.json
+++ b/projects/02_trivia_api/starter/frontend/package-lock.json
@@ -3563,20 +3563,6 @@
         "string.prototype.matchall": "^4.0.6"
       }
     },
-    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
@@ -7008,11 +6994,16 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "hasInstallScript": true,
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/projects/02_trivia_api/starter/frontend/package.json
+++ b/projects/02_trivia_api/starter/frontend/package.json
@@ -20,6 +20,9 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+  "overrides": {
+    "ejs": "3.1.10"
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
## Summary

- **Vulnerability**: GHSA-phwq-j96m-2c2q — `ejs` template injection / RCE
- **Severity**: Critical (CVSS 9.8, unauthenticated remote code execution)
- **Also fixes**: GHSA-ghr5-ch3p-vcr6 — `ejs` prototype pollution (< 3.1.10)
- **Root cause**: `corsproxy@1.5.0` (direct dep) pins `ejs@2.7.4`; no newer corsproxy release exists
- **Fix**: Added `overrides.ejs = "3.1.10"` in `package.json` to force the safe version across the whole dependency tree

## Details

`ejs` versions before 3.1.7 allow arbitrary code execution via malicious template options (e.g. `outputFunctionName`). This was reachable through `corsproxy`, which has no update available. The npm `overrides` mechanism pins the resolved version without removing corsproxy.

After this fix, `npm audit` reports **0 critical vulnerabilities**.

## Test plan

- [ ] Run `npm ls ejs` in `projects/02_trivia_api/starter/frontend` — both ejs entries should show `3.1.10`
- [ ] Run `npm audit` — confirm zero critical vulnerabilities
- [ ] Confirm frontend starts without errors (`npm start`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)