### PR TITLE
fix: resolve all high severity vulnerabilities in trivia frontend

### DIFF
--- a/projects/02_trivia_api/starter/frontend/package-lock.json
+++ b/projects/02_trivia_api/starter/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "trivia-app",
       "version": "0.1.0",
       "dependencies": {
-        "corsproxy": "^1.5.0",
         "jquery": "^3.5.0",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",
@@ -4454,20 +4453,6 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead"
     },
-    "node_modules/accept": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/accept/-/accept-1.1.0.tgz",
-      "integrity": "sha512-HDv67+8yQOc2AxloyYtzOE5QEoTq0zS2DHs5b/qr47QlwBxMUAikAvNBM2xYPzzG4OQhl87VZffCwfG5ZFtnWQ==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4614,20 +4599,6 @@
       },
       "peerDependencies": {
         "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/ammo": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ammo/-/ammo-1.0.1.tgz",
-      "integrity": "sha512-AnMKJci9zyOu1FGBfywS9IVm9VMA8ektGA2ox/2wQUDzdKbKLXFbmWPaecRO7DGBa5SLVZhjDc//6gTSFvpstw==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
       }
     },
     "node_modules/ansi-escapes": {
@@ -4990,19 +4961,6 @@
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/b64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/b64/-/b64-2.0.1.tgz",
-      "integrity": "sha512-q1mrmys21xu5BsrmBdpXKh4Scgw93LQIuFdL66JMH3v+KxeDqYbH5D2rq+G7PZcZDlaKzjgRBeEEXL0KzZU01g==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
       }
     },
     "node_modules/babel-jest": {
@@ -5467,19 +5425,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
-    "node_modules/boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -5571,20 +5516,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/call": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/call/-/call-2.0.2.tgz",
-      "integrity": "sha512-CgAcspL7M6KdqgZxxFIrVsg4wC0GHE6AMAjwFYjzlg/KFYAp+i4Nvg5fiqKgcF1cbkBacB4sQCUdFG7kBANe4g==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
       }
     },
     "node_modules/call-bind": {
@@ -5712,34 +5643,6 @@
       "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/catbox": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/catbox/-/catbox-6.0.0.tgz",
-      "integrity": "sha512-OyOpJyR3tyOq/EMGXhgB3TzCGD+QHeOQazNt5Wm/n0w1drFwKBFL0HVHFa3zTgtWfuDtnZSJbvQCzgRGaXqmXQ==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x",
-        "joi": "6.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
-    "node_modules/catbox-memory": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-1.1.2.tgz",
-      "integrity": "sha512-UcKPnS0uT68v4nwsFUIG0tdxEAAEKUDSkBuZn4ZB2C5I7OptznxdwiYGnlTdsCEhs40DboBUtruX76ZtQZRe+w==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.30"
       }
     },
     "node_modules/chalk": {
@@ -6009,20 +5912,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/content": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content/-/content-1.0.2.tgz",
-      "integrity": "sha512-GoVLEdUNleuL4Nv/V4+j9IJOeA6yC/jjmKOslXv6SNWiMwmz0cy7nYNp1Dg12uMZ02yhXCwpvp4Iij0yasTnJw==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -6098,51 +5987,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "node_modules/corsproxy": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/corsproxy/-/corsproxy-1.5.0.tgz",
-      "integrity": "sha512-dBPmB5dI9V/TbyDR8uOvpJEBPk3e8k+XICks4UuOgcVRBXEvaK3xjtR0r8z/yiLeTaD59QJZySwZyAvmXnLjBA==",
-      "license": "MIT",
-      "dependencies": {
-        "ejs": "^2.3.3",
-        "good": "^6.3.0",
-        "good-console": "^5.0.3",
-        "h2o2": "^4.0.1",
-        "hapi": "^9.0.2",
-        "hapi-cors-headers": "^1.0.0",
-        "http-proxy": "~1.11",
-        "inert": "^3.0.1",
-        "vision": "^3.0.0"
-      },
-      "bin": {
-        "corsproxy": "bin/corsproxy"
-      }
-    },
-    "node_modules/corsproxy/node_modules/eventemitter3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-      "integrity": "sha512-DOFqA1MF46fmZl2xtzXR3MPCRsXqgoFqdXcrCVYM3JNnfUeHTm/fh/v/iU7gBFpwkuBmoJPAm5GuhdDfSEJMJA==",
-      "license": "MIT"
-    },
-    "node_modules/corsproxy/node_modules/http-proxy": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.3.tgz",
-      "integrity": "sha512-dVzC6JlPUaRBONwMwVa/x1H5T0Gxn7VEldmfXuA++6+dE1a18VxfZoFIL2qHDVW4Eu+5m9ppPhm9ozeG/EhkmA==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "0.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/corsproxy/node_modules/requires-port": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz",
-      "integrity": "sha512-AzPDCliPoWDSvEVYRQmpzuPhGGEnPrQz9YiOEvn+UdB9ixBpw+4IOZWtwctmpzySLZTy7ynpn47V14H4yaowtA==",
-      "license": "MIT"
-    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -6170,19 +6014,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
       }
     },
     "node_modules/crypto-random-string": {
@@ -9076,97 +8907,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/good": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/good/-/good-6.6.3.tgz",
-      "integrity": "sha512-L50R4QKmYKuVN8A7VrRFKXfJ4n61EEmrgOOJon+otKjQrMo+/mZQHU1Fp8ayZsBaC4/pQxWPTE1iGMYyQw2oSw==",
-      "deprecated": "This module has moved and is now available at @hapi/good. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "hoek": "2.x.x",
-        "items": "1.x.x",
-        "joi": "6.x.x",
-        "traverse": "0.6.6",
-        "wreck": "6.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.x"
-      },
-      "peerDependencies": {
-        "hapi": ">=8.x.x"
-      }
-    },
-    "node_modules/good-console": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/good-console/-/good-console-5.3.2.tgz",
-      "integrity": "sha512-or2NyfALEVwlCf9nSKlKvhqZE5sBjvypWk0QuLFrk4sqfstjxBdxLNKjiQcmvGQVlupQKGpomffezOoJwt7IRA==",
-      "deprecated": "This module has moved and is now available at @hapi/good-console. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "good-squeeze": "2.x.x",
-        "hoek": "2.x.x",
-        "json-stringify-safe": "5.0.x",
-        "moment": "2.11.x",
-        "through2": "0.6.x"
-      },
-      "engines": {
-        "node": ">=0.10.x"
-      },
-      "peerDependencies": {
-        "good": ">= 6.x.x"
-      }
-    },
-    "node_modules/good-console/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/good-console/node_modules/moment": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz",
-      "integrity": "sha512-jAR7oRWEtmyOKFd10OE2480k4rLh62CpOGoohDV6cQzpRCGXUEk5dmkYNDvtz0Bnt+72tSMebgLmIsXgaX+L7A==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/good-console/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/good-console/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "node_modules/good-console/node_modules/through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "dependencies": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
-    "node_modules/good-squeeze": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/good-squeeze/-/good-squeeze-2.1.0.tgz",
-      "integrity": "sha512-rQx9AgCmQLvFzIak+0Bi56ObsOWzCxAFyjOxNxzJa0fxvMafGsfz+UHTKGwgr9IhTAKgVDwvRNWiKdE+k+JFVA==",
-      "deprecated": "This module has moved and is now available at @hapi/good-squeeze. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "hoek": "2.x.x",
-        "json-stringify-safe": "5.0.x"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -9203,70 +8943,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/h2o2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/h2o2/-/h2o2-4.0.2.tgz",
-      "integrity": "sha512-QBGH5VbVG8Jmv06jxNS77tdiWvwWPzZuXKXmnDF5zA5/coPbsEL0G0AJgrUfYIbIQ3RVamkmmoEx4qmhSabwaw==",
-      "deprecated": "This module has moved and is now available at @hapi/h2o2. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x",
-        "joi": "6.x.x",
-        "wreck": "6.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
-    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
-    },
-    "node_modules/hapi": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-9.5.1.tgz",
-      "integrity": "sha512-bc7Edlg0TQ3oszNLzCwQ4rDYRZHvCZ+Mxi79TVytqkxJ5qyEL8mX0el0hLGFF4MpCuaZiyIMMxcbS2wb5Kse8w==",
-      "deprecated": "This version contains severe security issues and defects and should not be used! Please upgrade to the latest version of @hapi/hapi or consider a commercial license (https://github.com/hapijs/hapi/issues/4114)",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "accept": "1.x.x",
-        "ammo": "1.x.x",
-        "boom": "^2.5.x",
-        "call": "2.x.x",
-        "catbox": "6.x.x",
-        "catbox-memory": "1.x.x",
-        "cryptiles": "2.x.x",
-        "heavy": "3.x.x",
-        "hoek": "^2.14.x",
-        "iron": "2.x.x",
-        "items": "1.x.x",
-        "joi": "^6.8.1",
-        "kilt": "^1.1.x",
-        "mimos": "2.x.x",
-        "peekaboo": "1.x.x",
-        "qs": "4.x.x",
-        "shot": "^1.7.x",
-        "statehood": "2.x.x",
-        "subtext": "2.x.x",
-        "topo": "^1.1.x"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/hapi-cors-headers": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hapi-cors-headers/-/hapi-cors-headers-1.0.3.tgz",
-      "integrity": "sha512-U/y+kpVLUJ0y86fEk8yleou9C1T5wFopcWQjuxKdMXzCcymTjfSqGz59waqvngUs1SbeXav/y8Ga9C0G0L1MGg=="
-    },
-    "node_modules/hapi/node_modules/qs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-      "integrity": "sha512-8MPmJ83uBOPsQj5tQCv4g04/nTiY+d17yl9o3Bw73vC6XlEm2POIRRlOgWJ8i74bkGLII670cDJJZkgiZ2sIkg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/harmony-reflect": {
       "version": "1.6.2",
@@ -9357,21 +9037,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/heavy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/heavy/-/heavy-3.0.1.tgz",
-      "integrity": "sha512-1U//1wbv50/LywV9mqAY0SSEDkYHxxCXZal8cOd6jgK4cxFP6jfoSgT0x/CUOiboiF+RDGtWvn/877CiObPq9A==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x",
-        "joi": "6.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
     "node_modules/history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -9384,16 +9049,6 @@
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
         "value-equal": "^1.0.1"
-      }
-    },
-    "node_modules/hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.40"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -9765,29 +9420,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inert": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/inert/-/inert-3.2.1.tgz",
-      "integrity": "sha512-IgX7s5c2GDdIinzghBkay5dJo2zlhSZztuHyNIkL7N3ZjZDrEMwjkHkT5rJquThDr6ywy1cZroQCGXsj4UciUw==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ammo": "1.x.x",
-        "boom": "2.x.x",
-        "hoek": "2.x.x",
-        "items": "1.x.x",
-        "joi": "^6.7.x",
-        "lru-cache": "2.7.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
-    "node_modules/inert/node_modules/lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -9827,21 +9459,6 @@
       "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/iron": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/iron/-/iron-2.1.3.tgz",
-      "integrity": "sha512-F0TZZhDcpexFAlXQtkAY7gVrMJhCsXmK1SSj8ohbgwPH/F+2CBBca2j/F1Bt6csv9bbaHFJiSokCzW/fiGHeFg==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
       }
     },
     "node_modules/is-arguments": {
@@ -10302,14 +9919,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
-    "node_modules/isemail": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -10423,15 +10032,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/items": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-1.1.1.tgz",
-      "integrity": "sha1-Q1td0hvKKLPP0lu1xrJ4txUBD9k=",
-      "deprecated": "This module has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version of hapi to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "engines": {
-        "node": ">=0.10.40"
       }
     },
     "node_modules/iterator.prototype": {
@@ -12442,23 +12042,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/joi": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-      "integrity": "sha512-K6+OwGaWM1sBEu+XMbgC4zDmg6hnddS2DWiCVtjnhkcrzv+ejSfh7HGUsoxmWQkv6kHEsVFAywttfkpmIE2QwQ==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "hoek": "2.x.x",
-        "isemail": "1.x.x",
-        "moment": "2.x.x",
-        "topo": "1.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40",
-        "npm": ">=2.0.0"
-      }
-    },
     "node_modules/jquery": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
@@ -12564,11 +12147,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -12642,18 +12220,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kilt": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/kilt/-/kilt-1.1.1.tgz",
-      "integrity": "sha512-j6qVf+w10bxAvgCDyLx6tfza3lpPmjFMkg0HcVvWIvCL4CQ1VMeN6VNWhKDBGTeqc1iBz3pHPbgVfGeQNYQuoQ==",
-      "deprecated": "This module is no longer maintained.",
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.30"
       }
     },
     "node_modules/kind-of": {
@@ -12987,19 +12553,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimos": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mimos/-/mimos-2.0.2.tgz",
-      "integrity": "sha512-Ig1xWtcdT8l0H7tmtaRzZMUfJhTon7Bcg3dybu+Pk7IQRKQQBPJ9og4H3Nk2cwEOM/MrcbY2ogJc6QMMHNxW0g==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "hoek": "2.x.x",
-        "mime-db": "1.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
-    },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.1.tgz",
@@ -13123,14 +12676,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13198,19 +12743,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "node_modules/nigel": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nigel/-/nigel-1.0.1.tgz",
-      "integrity": "sha512-bs0NxZsCVwz2Uzu/OyOyACETg3pXqPtWLt+k/E4G1Wo0cwc1YeSmDoH2dCz95fqrhKTsx9sHCcNR1amm8dCT5g==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "hoek": "2.x.x",
-        "vise": "1.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -13684,35 +13216,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/peekaboo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/peekaboo/-/peekaboo-1.0.0.tgz",
-      "integrity": "sha512-iqwB77z9VbRdHkBKt/MiwsARis45Jv8XO4Sm/So7yncwyDOtcd8wVglpLmQZQr5I4Ux/B2u+NIKNaEtBIOSvwA==",
-      "deprecated": "This module is no longer maintained.",
-      "engines": {
-        "node": ">=0.10.32"
-      }
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
-    },
-    "node_modules/pez": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pez/-/pez-1.0.0.tgz",
-      "integrity": "sha512-5A4pXNMpVIxqCkFPSHf7hgXq9i67sWsK5K9+P5xn2Iw5fbcXV2SNuKWf6nVRRf3P9Gq2VLgj9lEbkuLjetrgbg==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "b64": "2.x.x",
-        "boom": "2.x.x",
-        "content": "1.x.x",
-        "hoek": "2.x.x",
-        "nigel": "1.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -15283,14 +14790,6 @@
         "performance-now": "^2.1.0"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -16191,14 +15690,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/rollup-plugin-terser/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/rollup-plugin-terser/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -16448,11 +15939,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {
@@ -16598,19 +16090,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/shot": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/shot/-/shot-1.7.0.tgz",
-      "integrity": "sha512-6v6On/Z6PGQWPoaJPo9lV3On1dJ6B4rh/hm1Fv0AcOuk1Ml9OhBDRkZ8Gz1qDBeqR2bu1LtqZ2pPDKI5DeMpxA==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
       }
     },
     "node_modules/side-channel": {
@@ -16850,24 +16329,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
-    },
-    "node_modules/statehood": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/statehood/-/statehood-2.1.1.tgz",
-      "integrity": "sha512-dItbtl77c9yQdnJ66Ky3BaxP+rLuFpT3AoUmaBI8Wc7boMwjyxc57eAgNMJHL+bBRImWCQ6q0YrZ4+5UG8sY9Q==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "iron": "2.x.x",
-        "items": "1.x.x",
-        "joi": "6.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
     },
     "node_modules/static-eval": {
       "version": "2.1.1",
@@ -17122,31 +16583,6 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
-    },
-    "node_modules/subtext": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/subtext/-/subtext-2.0.2.tgz",
-      "integrity": "sha512-tyr4OQmJaYLPY9SBUNplztD6rrD9TdEexZl9vY79kdRGLFFdNprKjgAL2rncCcC/C4ukMaSlLO2Bj9VN887DRA==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "content": "1.x.x",
-        "hoek": "2.x.x",
-        "pez": "1.x.x",
-        "qs": "5.x.x",
-        "wreck": "6.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
-    "node_modules/subtext/node_modules/qs": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.1.tgz",
-      "integrity": "sha512-sh/hmLUTLEiYFhSbRvkM4zj6fMWnbqQt9wrppR2LJA/U/u4xS2eWN8LBE1xc79ExYZJBVZYSMBv/INC7wpE+fw==",
-      "engines": ">=0.10.40",
-      "license": "BSD-3-Clause"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -17577,19 +17013,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/topo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha512-vpmONxdZoD0R3hzH0lovwv8QmsqZmGCDE1wXW9YGD/reiDOAbPKEgRDlBCAt8u8nJhav/s/I+r+1gvdpA11x7Q==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -17622,11 +17045,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "node_modules/tryer": {
       "version": "1.0.1",
@@ -17818,9 +17236,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -18022,34 +17440,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vise/-/vise-1.0.0.tgz",
-      "integrity": "sha512-wj1sS3OTkQr/BmJWziTUVMYf6XbQPiHN15POXsJwavwqcKNk7cht1GQJ4JG8kDiRRYpP0i230OW8lbg5jD3ZxQ==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "dependencies": {
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
-      }
-    },
-    "node_modules/vision": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vision/-/vision-3.0.0.tgz",
-      "integrity": "sha512-a20hD1cUMTwHzL/vQys35HdBJn486ymKqRPlUOt06N2JgjdBbQcZ3Qdtwdkj1+0b03EiwnGFjL9QmgPNtu7Wyg==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "^2.9.x",
-        "items": "^1.1.x",
-        "joi": "6.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.32"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -18794,20 +18184,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "node_modules/wreck": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
-      "integrity": "sha512-jRAfuPkekn1Mr+1qSB5UK53WXVbbqJKV9GYqe4ue1eStEyiICSES58jGXAbxF5hzSJupy9/F3GBu5YDxVGYdzw==",
-      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "boom": "2.x.x",
-        "hoek": "2.x.x"
-      },
-      "engines": {
-        "node": ">=0.10.40"
-      }
-    },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
@@ -18849,14 +18225,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
-    },
-    "node_modules/xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/projects/02_trivia_api/starter/frontend/package.json
+++ b/projects/02_trivia_api/starter/frontend/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "proxy": "http://127.0.0.1:5000/",
   "dependencies": {
-    "corsproxy": "^1.5.0",
     "jquery": "^3.5.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
@@ -21,7 +20,9 @@
     "extends": "react-app"
   },
   "overrides": {
-    "ejs": "3.1.10"
+    "ejs": "3.1.10",
+    "serialize-javascript": "7.0.6",
+    "underscore": "1.13.8"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary

Eliminates all 42 high-severity vulnerabilities in `projects/02_trivia_api/starter/frontend`. Three changes:

### 1. Remove `corsproxy` (unused direct dependency)
`corsproxy@1.5.0` was never used in source code — CRA's built-in `"proxy"` field in `package.json` already handles API proxying. Removing it drops the entire legacy `hapi` / `hoek` / `boom` ecosystem that was responsible for ~34 high advisories (prototype pollution, DoS, route-bypass CVEs).

### 2. Override `serialize-javascript` → `7.0.6`
- **GHSA-5c6j-r48x-rmvq** — RCE via `RegExp.flags` / `Date.prototype.toISOString()` (CVSS 8.1, range `<=7.0.2`)
- **GHSA-qj8w-gfj5-8c6v** — CPU exhaustion DoS (range `>=5.0.0 <7.0.5`)

Both nested copies inside `react-scripts` (via `css-minimizer-webpack-plugin` at 6.0.2 and `rollup-plugin-terser` at 4.0.0) are now forced to 7.0.6.

### 3. Override `underscore` → `1.13.8`
- **GHSA-qpx9-hpmf-5gmw** — unlimited recursion DoS in `_.flatten` / `_.isEqual` (range `<=1.13.7`)

Was 1.13.6 inside `react-scripts → bfj → jsonpath → underscore`.

## Result

| Severity | Before | After |
|----------|--------|-------|
| Critical | 0      | 0     |
| High     | 42     | **0** |
| Moderate | 28     | 28    |
| Low      | 4      | 4     |
| **Total**| 74     | **32**|

## Test plan

- [ ] `npm audit` in `projects/02_trivia_api/starter/frontend` shows 0 critical, 0 high
- [ ] `npm ls serialize-javascript` shows `7.0.6` for all entries
- [ ] `npm ls underscore` shows `1.13.8`
- [ ] Frontend starts without errors (`npm start`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)