### PR TITLE
fix: eliminate ecdsa timing attack by switching to python-jose[cryptography]

### DIFF
--- a/BasicFlaskAuth/requirements.txt
+++ b/BasicFlaskAuth/requirements.txt
@@ -1,6 +1,5 @@
 astroid==2.2.5
 Click==7.0
-ecdsa==0.19.2
 Flask==3.1.3
 future==1.0.0
 isort==4.3.18
@@ -9,9 +8,8 @@ Jinja2==3.1.5
 lazy-object-proxy==1.4.0
 MarkupSafe==1.1.1
 mccabe==0.6.1
-pycryptodome>=3.6.6
 pylint==2.3.1
-python-jose-cryptodome==1.3.2
+python-jose[cryptography]>=3.4.0
 six==1.12.0
 typed-ast==1.4.2
 Werkzeug>=3.1.8

--- a/projects/03_coffee_shop_full_stack/starter_code/backend/requirements.txt
+++ b/projects/03_coffee_shop_full_stack/starter_code/backend/requirements.txt
@@ -1,6 +1,5 @@
 astroid==2.2.5
 Click==7.0
-ecdsa==0.19.2
 Flask==3.1.3
 Flask-SQLAlchemy==2.4.0
 future==1.0.0
@@ -10,9 +9,8 @@ Jinja2==3.1.5
 lazy-object-proxy==1.4.0
 MarkupSafe==1.1.1
 mccabe==0.6.1
-pycryptodome==3.19.1
 pylint==2.3.1
-python-jose-cryptodome==1.3.2
+python-jose[cryptography]>=3.4.0
 six==1.12.0
 typed-ast==1.4.2
 Werkzeug>=3.1.8


### PR DESCRIPTION
## Summary

Fixes **GHSA-wj6h-64fc-37mp** — Minerva timing attack on P-256 in `python-ecdsa`. The `ecdsa` library has no patched version (the advisory range is `>= 0`, all versions affected). The fix is to eliminate the dependency entirely.

**Changes in `BasicFlaskAuth/requirements.txt` and `projects/03_coffee_shop_full_stack/starter_code/backend/requirements.txt`:**

| Removed | Replaced with |
|---------|--------------|
| `ecdsa==0.19.2` | *(no longer needed)* |
| `python-jose-cryptodome==1.3.2` | `python-jose[cryptography]>=3.4.0` |
| `pycryptodome` | *(no longer needed)* |

`python-jose[cryptography]` uses the `cryptography` package (OpenSSL-backed, constant-time ECDSA) instead of `python-ecdsa`. The `jose.jwt` API (`jwt.decode()`, `jwt.get_unverified_header()`, `ExpiredSignatureError`, `JWTClaimsError`) is identical — no application code changes required.

## Remaining unfixable high-severity alerts (10 Angular)

The other 10 high-severity alerts are XSS/DoS vulnerabilities in `@angular/common`, `@angular/core`, and `@angular/compiler` in the coffee shop frontend. **9 of these have `Fix: None` even on the latest Angular 19.2.25** — they are newly disclosed, unpatched vulnerabilities in Angular itself. The 10th (GHSA-58c5-g7wp-6w37, XSRF token leakage) requires upgrading from Angular 7 → 19, a multi-major-version migration outside the scope of security patching.

## Test plan

- [ ] `pip install -r BasicFlaskAuth/requirements.txt` installs without error
- [ ] `pip install -r projects/03_coffee_shop_full_stack/starter_code/backend/requirements.txt` installs without error
- [ ] `from jose import jwt` works in both environments
- [ ] GitHub Dependabot shows 0 `ecdsa` alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)