### PR TITLE
fix: bump Jinja2 3.1.5 → 3.1.6 to patch CVE-2025-27516

### DIFF
--- a/BasicFlaskAuth/requirements.txt
+++ b/BasicFlaskAuth/requirements.txt
@@ -4,7 +4,7 @@ Flask==3.1.3
 future==1.0.0
 isort==4.3.18
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 lazy-object-proxy==1.4.0
 MarkupSafe==1.1.1
 mccabe==0.6.1

--- a/FlaskRecap/requirements.txt
+++ b/FlaskRecap/requirements.txt
@@ -1,6 +1,6 @@
 Click==7.0
 Flask==3.1.3
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 Werkzeug==3.1.6

--- a/projects/02_trivia_api/starter/backend/requirements.txt
+++ b/projects/02_trivia_api/starter/backend/requirements.txt
@@ -5,7 +5,7 @@ Flask-Cors==6.0.0
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.4.0
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 MarkupSafe==1.1.1
 psycopg2-binary==2.8.2
 pytz==2019.1

--- a/projects/03_coffee_shop_full_stack/starter_code/backend/requirements.txt
+++ b/projects/03_coffee_shop_full_stack/starter_code/backend/requirements.txt
@@ -5,7 +5,7 @@ Flask-SQLAlchemy==2.4.0
 future==1.0.0
 isort==4.3.18
 itsdangerous==1.1.0
-Jinja2==3.1.5
+Jinja2==3.1.6
 lazy-object-proxy==1.4.0
 MarkupSafe==1.1.1
 mccabe==0.6.1


### PR DESCRIPTION
## Summary

- Bumps `Jinja2==3.1.5` → `Jinja2==3.1.6` in all four backend/service `requirements.txt` files
- Patches **CVE-2025-27516** (Jinja2 sandbox escape vulnerability) across the entire repo
- Affected files: `BasicFlaskAuth`, `FlaskRecap`, `projects/02_trivia_api/starter/backend`, `projects/03_coffee_shop_full_stack/starter_code/backend`

## Test plan

- [ ] Verify `pip-audit` reports no vulnerabilities for the updated requirements
- [ ] Confirm existing backend services start and run normally with Jinja2 3.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)