### PR TITLE
fix: override serialize-javascript >=7.0.3 to patch RCE (GHSA-5c6j-r48x-rmvq)

### DIFF
--- a/projects/03_coffee_shop_full_stack/starter_code/frontend/package-lock.json
+++ b/projects/03_coffee_shop_full_stack/starter_code/frontend/package-lock.json
@@ -15016,16 +15016,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
@@ -16283,13 +16273,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
+      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/projects/03_coffee_shop_full_stack/starter_code/frontend/package.json
+++ b/projects/03_coffee_shop_full_stack/starter_code/frontend/package.json
@@ -58,5 +58,8 @@
     "tslint": "~5.16.0",
     "typescript": "~3.1.6"
   },
-  "description": "An Ionic project"
+  "description": "An Ionic project",
+  "overrides": {
+    "serialize-javascript": ">=7.0.3"
+  }
 }


### PR DESCRIPTION
## Summary

- Adds an npm `overrides` entry in the Coffee Shop frontend `package.json` to force `serialize-javascript` to `>=7.0.3`
- Lockfile now resolves to `7.0.6` (was `6.0.2`)
- Patches **GHSA-5c6j-r48x-rmvq**: RCE vulnerability via `RegExp.flags` and `Date.prototype.toISOString()` in `serialize-javascript`

## Test plan

- [ ] Confirm Dependabot alert #585 is resolved after merge
- [ ] Verify `npm audit` no longer reports the `serialize-javascript` critical/high finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)